### PR TITLE
Use hash comments instead of docstrings

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ This project pulls Steam game metadata, lands the raw JSON in MinIO, moves it th
     │       ├── macros/
     │       ├── snapshots/
     │       └── tests/
+    ├── spark/
+    │   ├── jobs/            # PySpark entrypoints
+    │   ├── lib/             # shared helpers (session builder, UDFs, schemas)
+    │   ├── config/          # config loader for jobs
+    │   └── tests/           # lightweight unit tests
     ├── infra/
     │   ├── docker/
     │   └── terraform/

--- a/infra/spark/conf/spark-defaults.conf
+++ b/infra/spark/conf/spark-defaults.conf
@@ -1,0 +1,9 @@
+# Cluster-level defaults for Spark to talk to MinIO via S3A
+spark.hadoop.fs.s3a.endpoint                     http://minio:9000
+spark.hadoop.fs.s3a.path.style.access            true
+spark.hadoop.fs.s3a.impl                         org.apache.hadoop.fs.s3a.S3AFileSystem
+spark.hadoop.fs.s3a.connection.ssl.enabled       false
+spark.hadoop.fs.s3a.access.key                   minioadmin
+spark.hadoop.fs.s3a.secret.key                   minioadmin
+spark.hadoop.fs.s3a.fast.upload                  true
+spark.hadoop.fs.s3a.signing-algorithm            S3SignerType

--- a/spark/__init__.py
+++ b/spark/__init__.py
@@ -1,0 +1,1 @@
+# PySpark job package for the Steam data platform.

--- a/spark/config/__init__.py
+++ b/spark/config/__init__.py
@@ -1,0 +1,1 @@
+# Configuration utilities for PySpark jobs.

--- a/spark/config/loader.py
+++ b/spark/config/loader.py
@@ -1,0 +1,61 @@
+# Simple configuration loader for PySpark jobs.
+#
+# This module centralizes reading runtime configuration from environment
+# variables and optional JSON files. Jobs can consume the resulting
+# `JobConfig` dataclass to avoid duplicating config parsing logic and to
+# keep storage targets/configuration flexible per job.
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict
+
+
+@dataclass
+class JobConfig:
+    # Container for job settings.
+    #
+    # minio_endpoint: Endpoint for MinIO/S3A connections
+    # minio_access_key: Access key for MinIO
+    # minio_secret_key: Secret key for MinIO
+    # extras: Any additional, job-specific settings loaded from config files
+    #         or environment variables
+
+    minio_endpoint: str = "http://minio:9000"
+    minio_access_key: str = "minioadmin"
+    minio_secret_key: str = "minioadmin"
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+
+def _load_from_json(path: Path) -> Dict[str, Any]:
+    if not path.exists():
+        raise FileNotFoundError(f"Config file not found: {path}")
+    with path.open("r", encoding="utf-8") as fp:
+        return json.load(fp)
+
+
+def load_config(config_path: str | None = None) -> JobConfig:
+    # Load configuration from env vars and an optional JSON file.
+    #
+    # Parameters
+    # ----------
+    # config_path: str | None
+    #     Path to a JSON config file with overrides. If omitted, only
+    #     environment variables are used.
+
+    file_values: Dict[str, Any] = {}
+    if config_path:
+        file_values = _load_from_json(Path(config_path))
+
+    env_defaults = {
+        "minio_endpoint": os.getenv("MINIO_ENDPOINT", JobConfig.minio_endpoint),
+        "minio_access_key": os.getenv("MINIO_ACCESS_KEY", JobConfig.minio_access_key),
+        "minio_secret_key": os.getenv("MINIO_SECRET_KEY", JobConfig.minio_secret_key),
+    }
+
+    merged = env_defaults | {k: v for k, v in file_values.items() if k in env_defaults}
+    extras = {k: v for k, v in file_values.items() if k not in env_defaults}
+
+    return JobConfig(**merged, extras=extras)

--- a/spark/jobs/__init__.py
+++ b/spark/jobs/__init__.py
@@ -1,0 +1,1 @@
+# PySpark jobs for the Steam data platform.

--- a/spark/jobs/run_job.py
+++ b/spark/jobs/run_job.py
@@ -1,0 +1,39 @@
+# CLI entrypoint to run PySpark jobs with shared config/session wiring.
+from __future__ import annotations
+
+import argparse
+import importlib
+from typing import Callable
+
+from spark.config.loader import JobConfig, load_config
+from spark.lib.session import build_spark_session
+
+
+def _load_callable(job_name: str) -> Callable:
+    module = importlib.import_module(f"spark.jobs.{job_name}")
+    if not hasattr(module, "main"):
+        raise AttributeError(f"Job module {job_name} must expose a main() function")
+    return getattr(module, "main")
+
+
+def run_job(job_fn: Callable, app_name: str, config_path: str | None = None) -> None:
+    cfg = load_config(config_path)
+    spark_session = build_spark_session(app_name=app_name, config=cfg)
+    job_fn(spark_session, cfg)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run a PySpark job")
+    parser.add_argument("--job", required=True, help="Job module name under spark.jobs")
+    parser.add_argument("--config", help="Optional path to JSON config file")
+    return parser.parse_args()
+
+
+def main() -> None:  # pragma: no cover - thin wrapper
+    args = parse_args()
+    job_callable = _load_callable(args.job)
+    run_job(job_callable, app_name=args.job, config_path=args.config)
+
+
+if __name__ == "__main__":
+    main()

--- a/spark/lib/__init__.py
+++ b/spark/lib/__init__.py
@@ -1,0 +1,1 @@
+# Shared utilities for PySpark jobs.

--- a/spark/lib/session.py
+++ b/spark/lib/session.py
@@ -1,0 +1,46 @@
+# SparkSession builder with MinIO/S3A defaults.
+from __future__ import annotations
+
+import os
+from pyspark.sql import SparkSession
+
+from spark.config.loader import JobConfig
+
+
+def build_spark_session(app_name: str = "steam-pyspark", config: JobConfig | None = None) -> SparkSession:
+    # Construct a SparkSession configured for MinIO access.
+    #
+    # Parameters
+    # ----------
+    # app_name: str
+    #     Name to assign to the Spark application.
+    # config: JobConfig | None
+    #     Optional configuration object. If omitted, env defaults are used.
+
+    cfg = config or JobConfig()
+
+    builder = (
+        SparkSession.builder.appName(app_name)
+        .config("spark.hadoop.fs.s3a.endpoint", cfg.minio_endpoint)
+        .config("spark.hadoop.fs.s3a.path.style.access", "true")
+        .config("spark.hadoop.fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+        .config(
+            "spark.hadoop.fs.s3a.connection.ssl.enabled",
+            str(cfg.minio_endpoint.startswith("https")),
+        )
+        .config("spark.hadoop.fs.s3a.access.key", cfg.minio_access_key)
+        .config("spark.hadoop.fs.s3a.secret.key", cfg.minio_secret_key)
+        .config("spark.hadoop.fs.s3a.fast.upload", "true")
+        .config("spark.hadoop.fs.s3a.signing-algorithm", "S3SignerType")
+    )
+
+    # Allow callers to pass through extra Spark configs via environment if needed
+    extra_spark_configs = {
+        key.removeprefix("SPARK_CONFIG_").lower().replace("__", "."): value
+        for key, value in os.environ.items()
+        if key.startswith("SPARK_CONFIG_")
+    }
+    for conf_key, conf_value in extra_spark_configs.items():
+        builder = builder.config(conf_key, conf_value)
+
+    return builder.getOrCreate()

--- a/spark/lib/utils.py
+++ b/spark/lib/utils.py
@@ -1,0 +1,9 @@
+# Miscellaneous pure helper functions for testing and reuse.
+
+
+def multiply_by_two(value: int) -> int:
+    # Double an integer.
+    #
+    # Kept simple to enable lightweight unit tests without Spark.
+
+    return value * 2

--- a/spark/tests/test_utils.py
+++ b/spark/tests/test_utils.py
@@ -1,0 +1,6 @@
+from spark.lib.utils import multiply_by_two
+
+
+def test_multiply_by_two():
+    assert multiply_by_two(3) == 6
+    assert multiply_by_two(-1) == -2


### PR DESCRIPTION
Adding pyspark structure and configs