### PR TITLE
Fix Airflow Dockerfile requirements path

### DIFF
--- a/infra/docker/airflow/Dockerfile
+++ b/infra/docker/airflow/Dockerfile
@@ -1,5 +1,5 @@
 FROM apache/airflow:2.10.3
 
 USER airflow
-COPY requirements.txt /requirements.txt
+COPY infra/docker/airflow/requirements.txt /requirements.txt
 RUN pip install --no-cache-dir -r /requirements.txt


### PR DESCRIPTION
## Summary
- point the Dockerfile to the requirements file in infra/docker/airflow

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694c5c589234832690befa574981bdbb)